### PR TITLE
Fix: Gangs exist with no real players (MasterKc12)

### DIFF
--- a/pawn/Entities/Gangs/GangCommands.pwn
+++ b/pawn/Entities/Gangs/GangCommands.pwn
@@ -245,11 +245,11 @@ class GangCommands {
                 return 1;
             }
         }
-        
+
         // Checks if the user is ALREADY in any gang.
- 		if (GangPlayer(playerId)->gangId() == Gang::InvalidId) {
- 			Gang(gangId)->onPlayerLeave(playerId);
- 		}
+        if (GangPlayer(playerId)->gangId() == Gang::InvalidId) {
+            Gang(gangId)->onPlayerLeave(playerId);
+        }
 
         // Join the gang. The Gang::onPlayerJoin() message will announce it to the gang and set up
         // to player's state to make sure they're member of the gang.


### PR DESCRIPTION
This simply kicks players from their current gangs before joining to
another one.
This case is currently possible only for admins, as they can join gangs
without requests, which gives a wrong player count to his previous gang.
(Fix by MasterKc12)
